### PR TITLE
Update repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/yourusername/gguf-downloader.git
-   cd gguf-downloader
+   https://github.com/olamide226/ollama-gguf-downloader
+   cd ollama-gguf-downloader
    ```
 
 2. (Optional but recommended) Create and activate a virtual environment:


### PR DESCRIPTION
This pull request updates the repository information in the setup instructions found in the `README.md` file to reflect the correct GitHub repository URL and directory name.

* Setup instructions now use the correct repository URL (`https://github.com/olamide226/ollama-gguf-downloader`) and directory name (`ollama-gguf-downloader`) in the clone and change directory commands.

Ref #4