### PR TITLE
feat: pause, resume, parallel download

### DIFF
--- a/download_gguf.py
+++ b/download_gguf.py
@@ -1,154 +1,425 @@
+#!/usr/bin/env python3
+
 import argparse
+import json
+import math
 import os
+import shutil
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
-from colorama import Fore, Style
+from colorama import Fore, Style, init
 from tqdm import tqdm
+
+init(autoreset=True)
+
+CHUNK_SIZE = 64 * 1024 * 1024  # 64 MB
 
 
 def fetch_manifest(model_name, model_parameters):
-    """Fetch the manifest for a model from the Ollama registry."""
-    # First try the standard library format
     url = f"https://registry.ollama.ai/v2/library/{model_name}/manifests/{model_parameters}"
+
     try:
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()  # Raise an error for bad status codes
-        return response.json(), "library"
-    except requests.exceptions.HTTPError as e:
+        response = requests.get(url, timeout=30)
+
+        if response.status_code == 200:
+            return response.json(), "library"
+
         if response.status_code == 404:
-            print(
-                f"{Fore.YELLOW}[INFO]{Style.RESET_ALL} Model not found in library, trying user-specific format..."
-            )
-            # Try with user-specific format only if model_name contains a slash
             if "/" in model_name:
                 user, model = model_name.split("/", 1)
-                fallback_url = f"https://registry.ollama.ai/v2/{user}/{model}/manifests/{model_parameters}"
-                fallback_model_name = model
 
-                try:
-                    fallback_response = requests.get(fallback_url, timeout=10)
-                    fallback_response.raise_for_status()
-                    return fallback_response.json(), fallback_model_name
-                except requests.exceptions.RequestException as fallback_e:
-                    print(
-                        f"{Fore.RED}[ERROR]{Style.RESET_ALL} Failed to fetch manifest from both library and user-specific formats: {fallback_e}"
-                    )
-                    sys.exit(1)
-            else:
-                print(
-                    f"{Fore.RED}[ERROR]{Style.RESET_ALL} Model not found in library. For user-specific models, use the format 'username/modelname'."
+                fallback_url = (
+                    f"https://registry.ollama.ai/v2/{user}/{model}/manifests/{model_parameters}"
                 )
-                sys.exit(1)
-        else:
-            print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Failed to fetch manifest: {e}")
-            sys.exit(1)
-    except requests.exceptions.RequestException as e:
-        print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Failed to fetch manifest: {e}")
-        sys.exit(1)
-    except ValueError:
-        print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Invalid JSON response from server.")
-        sys.exit(1)
 
+                fallback_response = requests.get(
+                    fallback_url,
+                    timeout=30,
+                )
 
-def download_file(url, filename, save_dir):
-    """Download a file from a URL and save it to a specified directory."""
-    os.makedirs(save_dir, exist_ok=True)  # Ensure directory exists
-    filepath = os.path.join(save_dir, filename)
+                fallback_response.raise_for_status()
 
-    try:
-        with requests.get(url, stream=True, allow_redirects=True, timeout=10) as r:
-            r.raise_for_status()
-            total_size = int(r.headers.get("content-length", 0))
-            block_size = 1024
-            t = tqdm(
-                total=total_size,
-                unit="iB",
-                unit_scale=True,
-                ncols=75,
-                bar_format=f"{Fore.GREEN}{{l_bar}}{{bar}}|{{n_fmt}}/{{total_fmt}}{Style.RESET_ALL}",
+                return fallback_response.json(), "user"
+
+            raise RuntimeError(
+                f"Model '{model_name}:{model_parameters}' not found."
             )
-            with open(filepath, "wb") as file:
-                for data in r.iter_content(block_size):
-                    t.update(len(data))
-                    file.write(data)
-            t.close()
-            if total_size != 0 and t.n != total_size:
-                print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Download incomplete.")
-                sys.exit(1)
-    except requests.exceptions.RequestException as e:
-        print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Failed to download file: {e}")
+
+        response.raise_for_status()
+
+    except Exception as e:
+        print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} {e}")
         sys.exit(1)
 
-    return filepath
+
+def get_blob_url(model_name, digest, source_type):
+    if source_type == "library":
+        return (
+            f"https://registry.ollama.ai/v2/library/{model_name}/blobs/{digest}"
+        )
+
+    user, model = model_name.split("/", 1)
+
+    return (
+        f"https://registry.ollama.ai/v2/{user}/{model}/blobs/{digest}"
+    )
+
+
+def get_file_info(url):
+    r = requests.head(
+        url,
+        allow_redirects=True,
+        timeout=60,
+    )
+
+    r.raise_for_status()
+
+    size = int(r.headers.get("content-length", 0))
+
+    supports_ranges = (
+        r.headers.get("accept-ranges", "").lower() == "bytes"
+    )
+
+    return size, supports_ranges
+
+
+def save_metadata(meta_file, metadata):
+    with open(meta_file, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+
+def load_metadata(meta_file):
+    if not os.path.exists(meta_file):
+        return None
+
+    with open(meta_file) as f:
+        return json.load(f)
+
+
+def download_chunk(
+    url,
+    part_file,
+    start,
+    end,
+    progress,
+):
+    expected_size = end - start + 1
+
+    existing = 0
+
+    if os.path.exists(part_file):
+        existing = os.path.getsize(part_file)
+
+        if existing == expected_size:
+            progress.update(existing)
+            return
+
+        if existing > expected_size:
+            os.remove(part_file)
+            existing = 0
+
+    headers = {
+        "Range": f"bytes={start + existing}-{end}"
+    }
+
+    with requests.get(
+        url,
+        headers=headers,
+        stream=True,
+        timeout=300,
+    ) as r:
+        r.raise_for_status()
+
+        with open(part_file, "ab") as f:
+            for chunk in r.iter_content(1024 * 1024):
+                if not chunk:
+                    continue
+
+                f.write(chunk)
+                progress.update(len(chunk))
+
+
+def merge_parts(
+    output_file,
+    parts_dir,
+    chunk_count,
+):
+    temp_output = output_file + ".merging"
+
+    print(
+        f"{Fore.CYAN}[INFO]{Style.RESET_ALL} Merging chunks..."
+    )
+
+    with open(temp_output, "wb") as out:
+
+        for idx in range(chunk_count):
+
+            part_file = os.path.join(
+                parts_dir,
+                f"part_{idx:05d}",
+            )
+
+            with open(part_file, "rb") as inp:
+
+                while True:
+                    data = inp.read(8 * 1024 * 1024)
+
+                    if not data:
+                        break
+
+                    out.write(data)
+
+    os.replace(temp_output, output_file)
+
+
+def cleanup(parts_dir):
+    if os.path.exists(parts_dir):
+        shutil.rmtree(parts_dir)
+
+
+def download_large_file(
+    url,
+    output_file,
+    workers=8,
+):
+    total_size, supports_ranges = get_file_info(url)
+
+    if not supports_ranges:
+        raise RuntimeError(
+            "Server does not support range requests."
+        )
+
+    if os.path.exists(output_file):
+        existing_size = os.path.getsize(output_file)
+
+        if existing_size == total_size:
+            print(
+                f"{Fore.GREEN}[SUCCESS]{Style.RESET_ALL} File already exists."
+            )
+            return
+
+    parts_dir = output_file + ".parts"
+
+    os.makedirs(parts_dir, exist_ok=True)
+
+    meta_file = os.path.join(
+        parts_dir,
+        "metadata.json",
+    )
+
+    chunk_count = math.ceil(
+        total_size / CHUNK_SIZE
+    )
+
+    metadata = {
+        "url": url,
+        "size": total_size,
+        "chunk_size": CHUNK_SIZE,
+        "chunk_count": chunk_count,
+    }
+
+    save_metadata(meta_file, metadata)
+
+    completed_bytes = 0
+
+    for idx in range(chunk_count):
+
+        start = idx * CHUNK_SIZE
+
+        end = min(
+            total_size - 1,
+            start + CHUNK_SIZE - 1,
+        )
+
+        expected_size = end - start + 1
+
+        part_file = os.path.join(
+            parts_dir,
+            f"part_{idx:05d}",
+        )
+
+        if (
+            os.path.exists(part_file)
+            and os.path.getsize(part_file)
+            == expected_size
+        ):
+            completed_bytes += expected_size
+
+    progress = tqdm(
+        total=total_size,
+        initial=completed_bytes,
+        unit="B",
+        unit_scale=True,
+        desc="Downloading",
+    )
+
+    futures = []
+
+    with ThreadPoolExecutor(
+        max_workers=workers
+    ) as executor:
+
+        for idx in range(chunk_count):
+
+            start = idx * CHUNK_SIZE
+
+            end = min(
+                total_size - 1,
+                start + CHUNK_SIZE - 1,
+            )
+
+            expected_size = end - start + 1
+
+            part_file = os.path.join(
+                parts_dir,
+                f"part_{idx:05d}",
+            )
+
+            if (
+                os.path.exists(part_file)
+                and os.path.getsize(part_file)
+                == expected_size
+            ):
+                continue
+
+            futures.append(
+                executor.submit(
+                    download_chunk,
+                    url,
+                    part_file,
+                    start,
+                    end,
+                    progress,
+                )
+            )
+
+        for future in as_completed(futures):
+            future.result()
+
+    progress.close()
+
+    print(
+        f"{Fore.CYAN}[INFO]{Style.RESET_ALL} Verifying chunks..."
+    )
+
+    for idx in range(chunk_count):
+
+        start = idx * CHUNK_SIZE
+
+        end = min(
+            total_size - 1,
+            start + CHUNK_SIZE - 1,
+        )
+
+        expected_size = end - start + 1
+
+        part_file = os.path.join(
+            parts_dir,
+            f"part_{idx:05d}",
+        )
+
+        if not os.path.exists(part_file):
+            raise RuntimeError(
+                f"Missing chunk: {part_file}"
+            )
+
+        actual_size = os.path.getsize(part_file)
+
+        if actual_size != expected_size:
+            raise RuntimeError(
+                f"Corrupt chunk: {part_file}"
+            )
+
+    merge_parts(
+        output_file,
+        parts_dir,
+        chunk_count,
+    )
+
+    cleanup(parts_dir)
+
+    print(
+        f"{Fore.GREEN}[SUCCESS]{Style.RESET_ALL} Download complete."
+    )
 
 
 def main():
-    """Main function to process arguments and download a GGUF model."""
     parser = argparse.ArgumentParser(
-        description="Download a .gguf model file from Ollama's registry",
-        epilog="Example: python download_gguf.py phi3 3.8b --save-dir /path/to/directory",
+        description="Download GGUF files from Ollama with resume support"
     )
+
     parser.add_argument(
-        "model_name", help="The name of the model to download (e.g., phi3)"
+        "model_name",
     )
+
     parser.add_argument(
-        "model_parameters", help="The model parameters to use (e.g., 3.8b)"
+        "model_parameters",
     )
+
     parser.add_argument(
         "--save-dir",
         default=".",
-        help="Directory to save the downloaded file (default: current directory)",
+    )
+
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Parallel download workers",
     )
 
     args = parser.parse_args()
 
-    model_name = args.model_name
-    model_parameters = args.model_parameters
-    save_dir = args.save_dir
+    manifest, source_type = fetch_manifest(
+        args.model_name,
+        args.model_parameters,
+    )
 
-    manifest, actual_model_name = fetch_manifest(model_name, model_parameters)
-
-    layers = manifest.get("layers", [])
     model_digest = None
 
-    for layer in layers:
-        if layer.get("mediaType") == "application/vnd.ollama.image.model":
-            model_digest = layer.get("digest")
+    for layer in manifest.get("layers", []):
+
+        if (
+            layer.get("mediaType")
+            == "application/vnd.ollama.image.model"
+        ):
+            model_digest = layer["digest"]
             break
 
     if not model_digest:
-        print(f"{Fore.RED}[ERROR]{Style.RESET_ALL} Model digest not found in manifest.")
+        print(
+            f"{Fore.RED}[ERROR]{Style.RESET_ALL} Model digest not found."
+        )
         sys.exit(1)
 
-    # Use the appropriate URL format based on what worked for the manifest
-    if actual_model_name == "library":
-        download_url = (
-            f"https://registry.ollama.ai/v2/library/{model_name}/blobs/{model_digest}"
-        )
-    else:
-        # For user-specific models, model_name should contain a slash
-        if "/" in model_name:
-            user, model = model_name.split("/", 1)
-            download_url = (
-                f"https://registry.ollama.ai/v2/{user}/{model}/blobs/{model_digest}"
-            )
-        else:
-            # This shouldn't happen given our validation above, but just in case
-            print(
-                f"{Fore.RED}[ERROR]{Style.RESET_ALL} Invalid model format for user-specific download."
-            )
-            sys.exit(1)
+    download_url = get_blob_url(
+        args.model_name,
+        model_digest,
+        source_type,
+    )
 
-    # Generate safe filename by replacing slashes with underscores
-    safe_model_name = model_name.replace("/", "_")
-    output_filename = f"{safe_model_name}_{model_parameters}.gguf"
+    safe_name = args.model_name.replace("/", "_")
+
+    output_file = os.path.join(
+        args.save_dir,
+        f"{safe_name}_{args.model_parameters}.gguf",
+    )
 
     print(
-        f"{Fore.CYAN}[INFO]{Style.RESET_ALL} Downloading {output_filename} to {save_dir}..."
+        f"{Fore.CYAN}[INFO]{Style.RESET_ALL} Download URL resolved."
     )
-    filepath = download_file(download_url, output_filename, save_dir)
-    print(f"{Fore.GREEN}[SUCCESS]{Style.RESET_ALL} Download completed: {filepath}")
+
+    print(
+        f"{Fore.CYAN}[INFO]{Style.RESET_ALL} Saving to: {output_file}"
+    )
+
+    download_large_file(
+        download_url,
+        output_file,
+        workers=args.workers,
+    )
 
 
 if __name__ == "__main__":

--- a/download_gguf.py
+++ b/download_gguf.py
@@ -78,9 +78,25 @@ def get_file_info(url):
 
     size = int(r.headers.get("content-length", 0))
 
-    supports_ranges = (
-        r.headers.get("accept-ranges", "").lower() == "bytes"
-    )
+    supports_ranges = False
+
+    try:
+        rr = requests.get(
+            url,
+            headers={"Range": "bytes=0-0"},
+            stream=True,
+            timeout=60,
+        )
+
+        supports_ranges = (
+            rr.status_code == 206
+            or "content-range" in rr.headers
+        )
+
+        rr.close()
+
+    except Exception:
+        pass
 
     return size, supports_ranges
 
@@ -130,16 +146,22 @@ def download_chunk(
         stream=True,
         timeout=300,
     ) as r:
-        r.raise_for_status()
+
+        if r.status_code not in (206,):
+            raise RuntimeError(
+                f"Server ignored Range request "
+                f"({r.status_code})"
+            )
 
         with open(part_file, "ab") as f:
-            for chunk in r.iter_content(1024 * 1024):
+            for chunk in r.iter_content(
+                1024 * 1024
+            ):
                 if not chunk:
                     continue
 
                 f.write(chunk)
                 progress.update(len(chunk))
-
 
 def merge_parts(
     output_file,
@@ -184,12 +206,7 @@ def download_large_file(
     output_file,
     workers=8,
 ):
-    total_size, supports_ranges = get_file_info(url)
-
-    if not supports_ranges:
-        raise RuntimeError(
-            "Server does not support range requests."
-        )
+    total_size, _ = get_file_info(url)
 
     if os.path.exists(output_file):
         existing_size = os.path.getsize(output_file)


### PR DESCRIPTION
closes #6

Features:
 - Resume interrupted downloads
 - Re-download only missing chunks
 - Verify chunk sizes
 - Merge automatically
 - Delete chunk files after successful merge
 - Works across restarts
 - Can optionally download chunks in parallel

New file pattern:
```
model.gguf.part_0
model.gguf.part_1
model.gguf.part_2
...
model.gguf.parts.json   # metadata
```

Example command: `python download_gguf.py batiai/minimax-m2.7 q3 --workers 8`

Blocking issue (upstream): **Server does not support range requests**

ref:
 - https://github.com/ollama/ollama/issues/16843